### PR TITLE
Prevent the default keypress event when playing a note

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,6 +101,7 @@ const Note: FunctionComponent<NoteProps> = ({ note, keyboard, white }) => {
     document.addEventListener("keydown", (e) => {
       if (keyboard.includes(e.key)) {
         pressNote();
+        e.preventDefault();
       }
     });
 


### PR DESCRIPTION
On Firefox, pressing "/" opens the Quick find bar which takes focus away from the piano. This change stops the shortcut from triggering so you can play without getting interrupted.